### PR TITLE
fix: Replace hardcoded localhost URLs with environment variables

### DIFF
--- a/client/src/App/Routes.jsx
+++ b/client/src/App/Routes.jsx
@@ -38,7 +38,7 @@ const DefaultRoute = () => {
 
       try {
         // Get user's projects to redirect to first available one
-        const response = await fetch('http://localhost:5000/projects', {
+        const response = await fetch(`${process.env.REACT_APP_API_URL || 'https://ticket-tracker.turing.com/api'}/projects`, {
           headers: {
             'Authorization': `Bearer ${getStoredAuthToken()}`,
             'Content-Type': 'application/json'
@@ -51,7 +51,7 @@ const DefaultRoute = () => {
             setRedirectPath(`/project/${data.projects[0].id}/board`);
           } else {
             // No projects available
-            const userResponse = await fetch('http://localhost:5000/currentUser', {
+            const userResponse = await fetch(`${process.env.REACT_APP_API_URL || 'https://ticket-tracker.turing.com/api'}/currentUser`, {
               headers: {
                 'Authorization': `Bearer ${getStoredAuthToken()}`,
                 'Content-Type': 'application/json'

--- a/client/src/shared/constants/config.js
+++ b/client/src/shared/constants/config.js
@@ -5,7 +5,7 @@ export const config = {
   GOOGLE_CLIENT_SECRET: process.env.REACT_APP_GOOGLE_CLIENT_SECRET || '',
   
   // API Configuration
-  API_URL: process.env.REACT_APP_API_URL || 'http://localhost:5000',
+  API_URL: process.env.REACT_APP_API_URL || 'https://ticket-tracker.turing.com/api',
   
   // Application Configuration
   APP_NAME: 'Ticket Tracker',

--- a/client/src/shared/utils/api.js
+++ b/client/src/shared/utils/api.js
@@ -6,7 +6,7 @@ import { objectToQueryString } from 'shared/utils/url';
 import { getStoredAuthToken, removeStoredAuthToken } from 'shared/utils/authToken';
 
 const defaults = {
-  baseURL: process.env.REACT_APP_API_URL || 'http://localhost:5000',
+  baseURL: process.env.REACT_APP_API_URL || 'https://ticket-tracker.turing.com/api',
   headers: () => ({
     'Content-Type': 'application/json',
     Authorization: getStoredAuthToken() ? `Bearer ${getStoredAuthToken()}` : undefined,


### PR DESCRIPTION
- Replace hardcoded localhost:5000 URLs in Routes.jsx with environment variable fallback
- Update api.js baseURL to use HTTPS production URL as fallback
- Update config.js API_URL to use HTTPS production URL as fallback
- Fixes connection refused errors in production environment
- Ensures proper API communication in both development and production

Resolves frontend connectivity issues when deployed to production server.