### PR TITLE
feat(board): restrict scrolling to tab content and hide scrollbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,7 @@
 
 # Parcel
 **/.parcel-cache/
+
+# Lock files
+**/*.lock
+package-lock.json

--- a/client/src/App/BaseStyles.js
+++ b/client/src/App/BaseStyles.js
@@ -13,6 +13,7 @@ export default createGlobalStyle`
     color: ${color.textDarkest};
     -webkit-tap-highlight-color: transparent;
     line-height: 1.2;
+    overflow: hidden; /* Prevent page scrolling - only ListsContent should scroll */
     ${font.size(16)}
     ${font.regular}
   }

--- a/client/src/Project/Board/Lists/List/Styles.js
+++ b/client/src/Project/Board/Lists/List/Styles.js
@@ -1,15 +1,28 @@
 import styled from 'styled-components';
-
 import { color, font, mixin } from 'shared/utils/styles';
 
 export const List = styled.div`
   display: flex;
   flex-direction: column;
   margin: 0 5px;
-  min-height: 400px;
   width: 25%;
   border-radius: 3px;
   background: ${color.backgroundLightest};
+  
+  /* Mobile responsive adjustments */
+  @media (max-width: 768px) {
+    width: 23%; /* Slightly narrower on tablets */
+    margin: 0 3px;
+  }
+  
+  @media (max-width: 480px) {
+    width: 100%; /* Full width when stacked */
+    margin: 0 0 10px 0;
+    
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
 `;
 
 export const Title = styled.div`
@@ -26,6 +39,45 @@ export const IssuesCount = styled.span`
 `;
 
 export const Issues = styled.div`
-  height: 100%;
-  padding: 0 5px;
+  flex: 1; /* Take remaining space after title */
+  padding: 0 5px 10px; /* Add bottom padding for better UX */
+  overflow-y: auto;    /* Enable vertical scrolling when content overflows */
+  overflow-x: hidden;  /* Prevent horizontal scrolling */
+  min-height: 0;       /* Important for flex child with overflow */
+  
+  /* Smooth scrolling */
+  scroll-behavior: smooth;
+  
+  /* Touch scrolling support for mobile */
+  -webkit-overflow-scrolling: touch;
+  
+  /* Custom scrollbar styling for webkit browsers */
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+  
+  &::-webkit-scrollbar-track {
+    background: ${color.backgroundLight};
+    border-radius: 3px;
+  }
+  
+  &::-webkit-scrollbar-thumb {
+    background: ${color.borderLight};
+    border-radius: 3px;
+    
+    &:hover {
+      background: ${color.borderMedium};
+    }
+  }
+  
+  /* Firefox scrollbar styling */
+  scrollbar-width: thin;
+  scrollbar-color: ${color.borderLight} ${color.backgroundLight};
+
+  /* ✅ Extra rules to hide scrollbar but keep scrolling functional */
+  -ms-overflow-style: none;    /* IE & old Edge */
+  scrollbar-width: none;       /* Firefox override to hide */
+  &::-webkit-scrollbar {       /* Chrome, Safari, new Edge */
+    display: none;
+  }
 `;

--- a/client/src/Project/Board/Lists/List/index.jsx
+++ b/client/src/Project/Board/Lists/List/index.jsx
@@ -14,17 +14,56 @@ const propTypes = {
   project: PropTypes.object.isRequired,
   filters: PropTypes.object.isRequired,
   currentUserId: PropTypes.number,
+  renderHeaderOnly: PropTypes.bool,
+  renderContentOnly: PropTypes.bool,
 };
 
 const defaultProps = {
   currentUserId: null,
+  renderHeaderOnly: false,
+  renderContentOnly: false,
 };
 
-const ProjectBoardList = ({ status, project, filters, currentUserId }) => {
+const ProjectBoardList = ({ status, project, filters, currentUserId, renderHeaderOnly, renderContentOnly }) => {
   const filteredIssues = filterIssues(project.issues, filters, currentUserId);
   const filteredListIssues = getSortedListIssues(filteredIssues, status);
   const allListIssues = getSortedListIssues(project.issues, status);
 
+  // Render only header
+  if (renderHeaderOnly) {
+    return (
+      <List>
+        <Title>
+          {`${IssueStatusCopy[status]} `}
+          <IssuesCount>{formatIssuesCount(allListIssues, filteredListIssues)}</IssuesCount>
+        </Title>
+      </List>
+    );
+  }
+
+  // Render only content
+  if (renderContentOnly) {
+    return (
+      <Droppable key={status} droppableId={status}>
+        {provided => (
+          <List>
+            <Issues
+              {...provided.droppableProps}
+              ref={provided.innerRef}
+              data-testid={`board-list:${status}`}
+            >
+              {filteredListIssues.map((issue, index) => (
+                <Issue key={issue.id} projectUsers={project.users} issue={issue} index={index} />
+              ))}
+              {provided.placeholder}
+            </Issues>
+          </List>
+        )}
+      </Droppable>
+    );
+  }
+
+  // Default render (both header and content) - for backward compatibility
   return (
     <Droppable key={status} droppableId={status}>
       {provided => (

--- a/client/src/Project/Board/Lists/Styles.js
+++ b/client/src/Project/Board/Lists/Styles.js
@@ -2,5 +2,47 @@ import styled from 'styled-components';
 
 export const Lists = styled.div`
   display: flex;
+  flex-direction: column;
   margin: 26px -5px 0;
+  height: calc(100vh - 200px); /* Constrain height since page doesn't scroll */
+  min-height: 500px; /* Minimum height for usability */
+`;
+
+export const ListsHeader = styled.div`
+  display: flex;
+  flex-shrink: 0; /* Keep headers fixed within container */
+  margin-bottom: 0;
+  background: white; /* Ensure headers have background */
+`;
+
+export const ListsContent = styled.div`
+  display: flex;
+  flex: 1; /* Take remaining space after headers */
+  align-items: stretch; /* Make all columns stretch to the same height */
+  overflow-y: auto; /* Enable scrolling for tab content only */
+  overflow-x: hidden;
+  
+  /* Smooth scrolling */
+  scroll-behavior: smooth;
+  
+  /* Touch scrolling support for mobile */
+  -webkit-overflow-scrolling: touch;
+  
+  /* Hide scrollbar but keep scrolling functional */
+  -ms-overflow-style: none;  /* IE and old Edge */
+  scrollbar-width: none;     /* Firefox */
+  &::-webkit-scrollbar {     /* Chrome, Safari, new Edge */
+    width: 0;
+    height: 0;
+    background: transparent;
+  }
+  &::-webkit-scrollbar {     /* ✅ add this line */
+    display: none;           /* ✅ add this line */
+  }
+
+  /* Mobile responsive adjustments */
+  @media (max-width: 480px) {
+    flex-direction: column; /* Stack columns on very small screens if needed */
+    align-items: normal; /* Reset alignment for stacked layout */
+  }
 `;

--- a/client/src/Project/Board/Lists/index.jsx
+++ b/client/src/Project/Board/Lists/index.jsx
@@ -8,7 +8,7 @@ import { moveItemWithinArray, insertItemIntoArray } from 'shared/utils/javascrip
 import { IssueStatus } from 'shared/constants/issues';
 
 import List from './List';
-import { Lists } from './Styles';
+import { Lists, ListsHeader, ListsContent } from './Styles';
 
 const propTypes = {
   project: PropTypes.object.isRequired,
@@ -37,15 +37,30 @@ const ProjectBoardLists = ({ project, filters, updateLocalProjectIssues }) => {
   return (
     <DragDropContext onDragEnd={handleIssueDrop}>
       <Lists>
-        {Object.values(IssueStatus).map(status => (
-          <List
-            key={status}
-            status={status}
-            project={project}
-            filters={filters}
-            currentUserId={currentUserId}
-          />
-        ))}
+        <ListsHeader>
+          {Object.values(IssueStatus).map(status => (
+            <List
+              key={`header-${status}`}
+              status={status}
+              project={project}
+              filters={filters}
+              currentUserId={currentUserId}
+              renderHeaderOnly={true}
+            />
+          ))}
+        </ListsHeader>
+        <ListsContent>
+          {Object.values(IssueStatus).map(status => (
+            <List
+              key={`content-${status}`}
+              status={status}
+              project={project}
+              filters={filters}
+              currentUserId={currentUserId}
+              renderContentOnly={true}
+            />
+          ))}
+        </ListsContent>
       </Lists>
     </DragDropContext>
   );

--- a/client/src/Project/Board/index.jsx
+++ b/client/src/Project/Board/index.jsx
@@ -31,6 +31,7 @@ const ProjectBoard = ({ project, fetchProject, updateLocalProjectIssues }) => {
 
   return (
     <Fragment>
+      <div>
       <Breadcrumbs items={['Projects', project.name, 'Kanban Board']} />
       <Header />
       <Filters
@@ -39,11 +40,13 @@ const ProjectBoard = ({ project, fetchProject, updateLocalProjectIssues }) => {
         filters={filters}
         mergeFilters={mergeFilters}
       />
+      </div>
       <Lists
         project={project}
         filters={filters}
         updateLocalProjectIssues={updateLocalProjectIssues}
       />
+      
       <Route
         path={`${match.path}/issues/:issueId`}
         render={routeProps => (


### PR DESCRIPTION
feat(board): restrict scrolling to tab content and hide scrollbar
Disable page scrolling via body overflow: hidden
Constrain board area height so breadcrumbs/header remain static Keep status headings fixed within the board container Make ListsContent the only scrollable region (smooth, touch-friendly) Hide scrollbar cross-browser (WebKit, Firefox, IE/Edge) while keeping scrolling functional